### PR TITLE
Improve demo experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 
 [**Visit the Demo →**](https://composed-input.vercel.app/)
 
+> 📱 데모 페이지에는 모바일 고정 키보드와 숫자·다이얼러 전용 모드를 직접 전환해 볼 수 있는 섹션이 준비되어 있습니다.
+> 실제 모바일 기기 혹은 DevTools 기기 모드(User-Agent 를 모바일로 전환)에 맞춰 접속하면 네이티브 키보드 대신 이 라이브러리의 가상 키보드가 표시됩니다.
+
 ---
 
 `virtual-keyboard` is a React component library that provides a custom virtual keyboard and input field, specifically designed to solve the infamous Korean `composition` event issues in web environments. It offers a seamless and native-like typing experience, free from common bugs like character duplication, cursor jumping, and broken compositions.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uiwwsw/virtual-keyboard",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "types": "dist/types/index.d.ts",
   "main": "dist/index.js",

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,267 @@
+:root {
+  font-family: "Pretendard", "Noto Sans KR", "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #0f172a;
+  background-color: #f5f7fb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, #edf2ff, #f5f7fb 55%);
+}
+
+#root {
+  min-height: 100vh;
+}
+
+.app-shell {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 48px 20px 96px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+.hero {
+  background: linear-gradient(135deg, #1d4ed8, #7c3aed);
+  color: white;
+  border-radius: 32px;
+  padding: 40px;
+  box-shadow: 0 30px 80px rgba(67, 56, 202, 0.25);
+}
+
+.hero h1 {
+  margin: 12px 0 16px;
+  font-size: clamp(28px, 4vw, 44px);
+  line-height: 1.25;
+}
+
+.lead {
+  font-size: 17px;
+  max-width: 720px;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.hero-actions {
+  margin-top: 28px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+}
+
+.btn.primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 14px 28px;
+  border-radius: 999px;
+  font-weight: 600;
+  background: white;
+  color: #1d4ed8;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 15px 35px rgba(15, 23, 42, 0.25);
+}
+
+.btn.primary:hover {
+  transform: translateY(-2px);
+}
+
+.hint {
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.eyebrow {
+  font-size: 13px;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  margin: 0;
+  opacity: 0.85;
+}
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 24px;
+}
+
+.demo-card {
+  background: white;
+  border-radius: 28px;
+  padding: 28px;
+  box-shadow: 0 40px 80px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.card-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: baseline;
+}
+
+.card-head h2 {
+  margin: 4px 0 0;
+}
+
+.subtitle {
+  margin: 0;
+  color: #475569;
+  font-size: 14px;
+  max-width: 220px;
+}
+
+.mobile-shell {
+  position: relative;
+  background: #05080f;
+  border-radius: 36px;
+  padding: 20px 20px 32px;
+  min-height: 560px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.05);
+}
+
+.mobile-notch {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 150px;
+  height: 18px;
+  background: rgba(255, 255, 255, 0.09);
+  border-radius: 999px;
+}
+
+.mobile-content {
+  background: #f7f8fb;
+  border-radius: 28px;
+  width: 100%;
+  height: 100%;
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.mobile-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.mobile-form virtual-input {
+  border: 1px solid #d0d7e3;
+  padding: 14px 16px;
+  background: white;
+}
+
+.mobile-form virtual-input .placeholder {
+  color: #9ca3af !important;
+}
+
+.mobile-help {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #475569;
+  padding: 12px 16px;
+  background: #e0e7ff;
+  border-radius: 16px;
+}
+
+.mode-buttons {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.mode-button {
+  border: 1px solid #dbe4ff;
+  border-radius: 16px;
+  padding: 12px 16px;
+  text-align: left;
+  background: #f8f9ff;
+  font-weight: 600;
+  color: #1e1b4b;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.mode-button small {
+  font-weight: 400;
+  color: #475569;
+}
+
+.mode-button.is-active {
+  border-color: #7c3aed;
+  background: linear-gradient(135deg, rgba(124, 58, 237, 0.15), rgba(59, 130, 246, 0.15));
+  box-shadow: 0 20px 35px rgba(99, 102, 241, 0.15);
+  transform: translateY(-2px);
+}
+
+.mode-description {
+  margin: 0;
+  font-size: 15px;
+  color: #475569;
+}
+
+.mode-input virtual-input {
+  border: 2px solid #d4d8f0;
+  padding: 18px 20px;
+  border-radius: 24px;
+  background: #fbfcff;
+}
+
+.guide {
+  background: #0f172a;
+  color: white;
+  border-radius: 32px;
+  padding: 32px;
+  line-height: 1.7;
+  box-shadow: 0 40px 80px rgba(15, 23, 42, 0.35);
+}
+
+.guide h3 {
+  margin-top: 0;
+}
+
+.guide ol {
+  padding-left: 18px;
+}
+
+.guide code {
+  background: rgba(255, 255, 255, 0.15);
+  padding: 3px 6px;
+  border-radius: 6px;
+}
+
+@media (max-width: 640px) {
+  .hero {
+    padding: 28px;
+  }
+  .demo-card {
+    padding: 22px;
+  }
+  .mobile-shell {
+    padding: 14px;
+    min-height: 480px;
+  }
+  .mobile-content {
+    padding: 18px;
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,41 +1,228 @@
+import { useMemo, useState, type ReactNode } from "react";
+import "./App.css";
 import { VirtualInput } from "./components/Input";
 import { VirtualInputProvider } from "./components/Provider";
+import type { KeypadLayout } from "./components/Keypad";
+
+const numberPadLayout: KeypadLayout = [
+  [
+    { label: "1", value: "1", type: "char" },
+    { label: "2", value: "2", type: "char" },
+    { label: "3", value: "3", type: "char" },
+  ],
+  [
+    { label: "4", value: "4", type: "char" },
+    { label: "5", value: "5", type: "char" },
+    { label: "6", value: "6", type: "char" },
+  ],
+  [
+    { label: "7", value: "7", type: "char" },
+    { label: "8", value: "8", type: "char" },
+    { label: "9", value: "9", type: "char" },
+  ],
+  [
+    { label: "·", value: ".", type: "char" },
+    { label: "0", value: "0", type: "char" },
+    { label: "⌫", value: "Backspace", type: "action" },
+  ],
+];
+
+const dialerLayout: KeypadLayout = [
+  [
+    { label: "1", value: "1", type: "char" },
+    { label: "2", value: "2", type: "char" },
+    { label: "3", value: "3", type: "char" },
+  ],
+  [
+    { label: "4", value: "4", type: "char" },
+    { label: "5", value: "5", type: "char" },
+    { label: "6", value: "6", type: "char" },
+  ],
+  [
+    { label: "7", value: "7", type: "char" },
+    { label: "8", value: "8", type: "char" },
+    { label: "9", value: "9", type: "char" },
+  ],
+  [
+    { label: "＊", value: "*", type: "char" },
+    { label: "0", value: "0", type: "char" },
+    { label: "#", value: "#", type: "char" },
+  ],
+  [
+    { label: "저장된 010", value: "010", width: 2, type: "char" },
+    { label: "⌫", value: "Backspace", type: "action" },
+  ],
+];
+
+type ModeKey = "hangul" | "number" | "dialer";
+
+const layoutModes: Record<ModeKey, {
+  title: string;
+  helper: string;
+  layout?: KeypadLayout;
+  defaultHangulMode?: boolean;
+}> = {
+  hangul: {
+    title: "한/영 풀키보드",
+    helper: "한국어 조합을 완벽히 처리하는 기본 QWERTY",
+    layout: undefined,
+    defaultHangulMode: true,
+  },
+  number: {
+    title: "숫자 패드",
+    helper: "계산기 · 결제 화면 · OTP 입력",
+    layout: numberPadLayout,
+    defaultHangulMode: false,
+  },
+  dialer: {
+    title: "다이얼러 + 매크로 키",
+    helper: "전화번호 전용 단축키와 함께",
+    layout: dialerLayout,
+    defaultHangulMode: false,
+  },
+};
+
+function DemoCard({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle: string;
+  children: ReactNode;
+}) {
+  return (
+    <article className="demo-card">
+      <div className="card-head">
+        <div>
+          <p className="eyebrow">데모</p>
+          <h2>{title}</h2>
+        </div>
+        <p className="subtitle">{subtitle}</p>
+      </div>
+      {children}
+    </article>
+  );
+}
+
+function MobileShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="mobile-shell">
+      <div className="mobile-notch" />
+      <div className="mobile-content">{children}</div>
+    </div>
+  );
+}
+
+function ModeButtons({
+  active,
+  onChange,
+}: {
+  active: ModeKey;
+  onChange: (key: ModeKey) => void;
+}) {
+  return (
+    <div className="mode-buttons">
+      {(Object.keys(layoutModes) as ModeKey[]).map((mode) => (
+        <button
+          key={mode}
+          type="button"
+          className={`mode-button ${active === mode ? "is-active" : ""}`}
+          onClick={() => onChange(mode)}
+        >
+          <span>{layoutModes[mode].title}</span>
+          <small>{layoutModes[mode].helper}</small>
+        </button>
+      ))}
+    </div>
+  );
+}
 
 function App() {
+  const [mode, setMode] = useState<ModeKey>("hangul");
+  const activeLayout = layoutModes[mode];
+
+  const modeDescription = useMemo(() => {
+    switch (mode) {
+      case "number":
+        return "결제나 OTP 같이 숫자만 필요한 화면에서 네이티브 숫자 키패드를 완전히 대체합니다.";
+      case "dialer":
+        return "매크로 키와 전화번호 입력을 조합해 고객센터/사번 내선 같은 반복 입력을 빠르게 처리합니다.";
+      default:
+        return "표준 QWERTY 자판 위에 조합 로직을 올려 모바일 웹에서도 한글 타이핑을 안정적으로 유지합니다.";
+    }
+  }, [mode]);
+
   return (
-    <>
-      <VirtualInputProvider>
-        <VirtualInput defaultValue="가나달" />
-      </VirtualInputProvider>
-      <VirtualInputProvider
-        layout={[
-          [
-            { value: "1", label: "1" },
-            { value: "2", label: "2" },
-            { value: "3", label: "3" },
-          ],
-          [
-            { value: "4", label: "4" },
-            { value: "5", label: "5" },
-            { value: "6", label: "6" },
-          ],
-          [
-            { value: "7", label: "7" },
-            { value: "8", label: "8" },
-            { value: "9", label: "9" },
-          ],
-          [
-            { value: "010", label: "010" },
-            { value: "0", label: "0" },
-            { label: "del", value: "Backspace", type: "action" },
-          ],
-        ]}
-      >
-        <VirtualInput placeholder="123123" />
-      </VirtualInputProvider>
-      <div>dwadawd</div>
-      <input type="text" />
-    </>
+    <div className="app-shell">
+      <header className="hero">
+        <p className="eyebrow">Virtual Keyboard Demo</p>
+        <h1>
+          모바일에서도 네이티브 키보드 대신<br /> 내가 만든 키보드를 띄우세요
+        </h1>
+        <p className="lead">
+          한국어 조합 버그를 해결하고, 숫자/전화/OTP 등 상황별 맞춤 키패드를 구성할 수 있는 React 가상 키보드
+          데모입니다.
+        </p>
+        <div className="hero-actions">
+          <a className="btn primary" href="https://composed-input.vercel.app/" target="_blank" rel="noreferrer">
+            새 창에서 전체 데모 열기 ↗
+          </a>
+          <span className="hint">실제 모바일 또는 DevTools 기기 모드에서 확인해보세요.</span>
+        </div>
+      </header>
+
+      <section className="demo-grid">
+        <DemoCard
+          title="모바일 고정 키보드"
+          subtitle="네이티브 키보드가 열리지 않고 가상 키보드만 보여집니다."
+        >
+          <MobileShell>
+            <VirtualInputProvider>
+              <div className="mobile-form">
+                <label>
+                  이름
+                  <VirtualInput placeholder="홍길동" />
+                </label>
+                <label>
+                  메모
+                  <VirtualInput placeholder="오늘 일정 정리..." />
+                </label>
+                <p className="mobile-help">
+                  모바일에서 접속하면 화면 하단에 이 라이브러리의 키보드만 표시됩니다.
+                </p>
+              </div>
+            </VirtualInputProvider>
+          </MobileShell>
+        </DemoCard>
+
+        <DemoCard
+          title="모드 전환"
+          subtitle="풀 키보드 ↔ 숫자 전용 ↔ 다이얼러를 즉시 바꿔보세요."
+        >
+          <ModeButtons active={mode} onChange={setMode} />
+          <p className="mode-description">{modeDescription}</p>
+          <VirtualInputProvider layout={activeLayout.layout} defaultHangulMode={activeLayout.defaultHangulMode}>
+            <div className="mode-input">
+              <VirtualInput placeholder="값을 입력하세요" />
+            </div>
+          </VirtualInputProvider>
+        </DemoCard>
+      </section>
+
+      <section className="guide">
+        <h3>모바일에서 테스트하는 방법</h3>
+        <ol>
+          <li>휴대폰으로 https://composed-input.vercel.app/ 에 접속합니다.</li>
+          <li>입력 필드를 탭하면 네이티브 키보드가 차단되고, 커스텀 키보드가 화면 하단에서 등장합니다.</li>
+          <li>개발자 도구 기기 모드에서도 User-Agent 를 모바일로 설정하면 동일한 동작을 확인할 수 있습니다.</li>
+        </ol>
+        <p>
+          각 데모는 <code>VirtualInputProvider</code> 의 <code>layout</code> 속성만 바꿔서 구성했습니다. 필요한 모양을
+          자유롭게 추가해보세요.
+        </p>
+      </section>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- redesign the demo application with a hero section, mobile preview shell, and mode-switching examples to highlight numeric and dialer layouts
- add dedicated keypad layouts for numeric and dialer scenarios and wire them into the demo providers
- document the new demo experience in the README

## Testing
- `npm run build`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915750402b083318c48a40aa5be14c3)