### PR TITLE
Fix dialer mode layout issues

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -220,6 +220,10 @@ body {
   color: #475569;
 }
 
+.mode-input {
+  display: flex;
+}
+
 .mode-input virtual-input {
   border: 2px solid #d4d8f0;
   padding: 18px 20px;

--- a/src/components/Keypad.tsx
+++ b/src/components/Keypad.tsx
@@ -52,22 +52,25 @@ export function VirtualKeypad({
 		if (!focusId) return;
 		onFocus(focusId);
 	}, [onFocus, focusId]);
-	const getTransformedValue = useCallback(
-		(cell: { label?: string; value: string; type?: string }) => {
-			if (cell.type === "char") {
-				if (hangulMode) {
-					return convertQwertyToHangul(cell.value);
-				}
-				if (shift) {
-					return cell.value.toUpperCase();
-				}
-				return cell.value;
-			}
+        const getTransformedValue = useCallback(
+                (cell: { label?: string; value: string; type?: string }) => {
+                        if (cell.type === "char") {
+                                const isConvertibleHangulSource =
+                                        hangulMode && /[a-zA-Z]/.test(cell.value) && cell.value.length === 1;
 
-			return cell.label ?? cell.value;
-		},
-		[hangulMode, shift],
-	);
+                                if (isConvertibleHangulSource) {
+                                        return convertQwertyToHangul(cell.value);
+                                }
+                                if (shift) {
+                                        return cell.value.toUpperCase();
+                                }
+                                return cell.value;
+                        }
+
+                        return cell.label ?? cell.value;
+                },
+                [hangulMode, shift],
+        );
 
         const insertCharacter = useCallback(
                 (e: MouseEvent<HTMLButtonElement>) => {
@@ -239,7 +242,7 @@ export function VirtualKeypad({
 
                                                         const style: CSSProperties = {};
                                                         if (cell.width) {
-                                                                style.flex = `0 0 calc(${cell.width}px / var(--scale-factor))`;
+                                                                style.flex = `${cell.width} 0 0`;
                                                         }
                                                         if (cell.height) {
                                                                 style.height = `calc(${cell.height}px / var(--scale-factor))`;


### PR DESCRIPTION
## Summary
- ensure keypad cells that define a `width` span proportionally instead of shrinking to a pixel value so the dialer + macro preset renders correctly
- add `display: flex` to the `.mode-input` wrapper so the embedded `virtual-input` component keeps its intended width
- guard Hangul conversion so it only runs for single latin characters, preventing the dialer/macro preset from crashing when Hangul mode is active

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691578e054548331822e63c6348d9a08)