### PR TITLE
Improve keypad layering and viewport handling

### DIFF
--- a/src/components/Keypad.tsx
+++ b/src/components/Keypad.tsx
@@ -126,6 +126,7 @@ export function VirtualKeypad({
           box-shadow: 0 calc(-6px / var(--scale-factor)) calc(30px / var(--scale-factor)) rgba(15, 23, 42, 0.2);
           user-select: none;
           touch-action: manipulation;
+          z-index: 9999;
         }
         .keypad-row {
           display: flex;
@@ -182,6 +183,8 @@ export function VirtualKeypad({
           border-radius: calc(10px / var(--scale-factor));
           box-shadow: 0 calc(-4px / var(--scale-factor)) calc(18px / var(--scale-factor)) rgba(15, 23, 42, 0.18);
           pointer-events: none;
+          touch-action: none;
+          user-select: none;
           font-size: calc(26px / var(--scale-factor));
           font-weight: 500;
           text-align: center;

--- a/src/hooks/useVisualViewport.ts
+++ b/src/hooks/useVisualViewport.ts
@@ -1,45 +1,74 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 
 const getVisualViewport = () => {
-	if (typeof window !== "undefined" && window.visualViewport) {
-		return {
-			width: window.visualViewport.width,
-			height: window.visualViewport.height,
-			scale: window.visualViewport.scale,
-			offsetLeft: window.visualViewport.offsetLeft,
-			offsetTop: window.visualViewport.offsetTop,
-		};
-	}
-	return {
-		width: window.innerWidth,
-		height: window.innerHeight,
-		scale: 1,
-		offsetLeft: 0,
-		offsetTop: 0,
-	};
+        if (typeof window !== "undefined" && window.visualViewport) {
+                return {
+                        width: window.visualViewport.width,
+                        height: window.visualViewport.height,
+                        scale: window.visualViewport.scale,
+                        offsetLeft: window.visualViewport.offsetLeft,
+                        offsetTop: window.visualViewport.offsetTop,
+                };
+        }
+        return {
+                width: window.innerWidth,
+                height: window.innerHeight,
+                scale: 1,
+                offsetLeft: 0,
+                offsetTop: 0,
+        };
 };
 
+const isSameViewport = (
+        prev: ReturnType<typeof getVisualViewport>,
+        next: ReturnType<typeof getVisualViewport>,
+) =>
+        prev.width === next.width &&
+        prev.height === next.height &&
+        prev.scale === next.scale &&
+        prev.offsetLeft === next.offsetLeft &&
+        prev.offsetTop === next.offsetTop;
+
 export const useVisualViewport = () => {
-	const [viewport, setViewport] = useState(getVisualViewport);
+        const [viewport, setViewport] = useState(getVisualViewport);
 
-	useEffect(() => {
-		const handleResize = () => {
-			setViewport(getVisualViewport());
-		};
+        useEffect(() => {
+                if (typeof window === "undefined") return;
 
-		if (typeof window !== "undefined" && window.visualViewport) {
-			window.visualViewport.addEventListener("resize", handleResize);
-			window.visualViewport.addEventListener("scroll", handleResize);
-			return () => {
-				window.visualViewport?.removeEventListener("resize", handleResize);
-				window.visualViewport?.removeEventListener("scroll", handleResize);
-			};
-		}
+                let rafId: number | null = null;
 
-		// Fallback for older browsers
-		window.addEventListener("resize", handleResize);
-		return () => window.removeEventListener("resize", handleResize);
-	}, []);
+                const applyViewportUpdate = () => {
+                        const nextViewport = getVisualViewport();
+                        setViewport((prev) => (isSameViewport(prev, nextViewport) ? prev : nextViewport));
+                };
 
-	return viewport;
+                const handleResize = () => {
+                        if (rafId !== null) {
+                                cancelAnimationFrame(rafId);
+                        }
+                        rafId = requestAnimationFrame(applyViewportUpdate);
+                };
+
+                if (window.visualViewport) {
+                        window.visualViewport.addEventListener("resize", handleResize, { passive: true });
+                        window.visualViewport.addEventListener("scroll", handleResize, { passive: true });
+                } else {
+                        // Fallback for older browsers
+                        window.addEventListener("resize", handleResize, { passive: true });
+                }
+
+                return () => {
+                        if (rafId !== null) {
+                                cancelAnimationFrame(rafId);
+                        }
+                        if (window.visualViewport) {
+                                window.visualViewport.removeEventListener("resize", handleResize);
+                                window.visualViewport.removeEventListener("scroll", handleResize);
+                        } else {
+                                window.removeEventListener("resize", handleResize);
+                        }
+                };
+        }, []);
+
+        return viewport;
 };


### PR DESCRIPTION
## Summary
- prevent key popup animation from intercepting user interactions and raise keypad layering to sit above surrounding UI
- throttle visualViewport updates with requestAnimationFrame and equality checks to smooth scroll performance

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928e45cd8208331885a02db02c02456)