### PR TITLE
Limit interaction blocking to keypad overlay

### DIFF
--- a/src/components/Keypad.tsx
+++ b/src/components/Keypad.tsx
@@ -4,7 +4,7 @@
 /** biome-ignore-all lint/a11y/noStaticElementInteractions: <explanation> */
 import { isMobileAgent } from "../utils/isMobileAgent";
 import { useVirtualInputContext } from "./Context";
-import { useCallback, type MouseEvent, type CSSProperties } from "react";
+import { useCallback, type MouseEvent, type CSSProperties, type SyntheticEvent } from "react";
 import { ShadowWrapper } from "./ShadowWrapper";
 import { convertQwertyToHangul } from "es-hangul";
 
@@ -106,10 +106,18 @@ export function VirtualKeypad({
 				shiftKey: shift,
 			});
 			inputRef.current?.handleKeyDown(event);
-		},
-		[inputRef, shift, toggleShift, toggleKorean, getTransformedValue],
-	);
-	if (!focusId || !isMobileAgent()) return null;
+                },
+                [inputRef, shift, toggleShift, toggleKorean, getTransformedValue],
+        );
+
+        const preventContextMenu = useCallback((event: MouseEvent<HTMLDivElement>) => {
+                event.preventDefault();
+        }, []);
+
+        const preventSelection = useCallback((event: SyntheticEvent) => {
+                event.preventDefault();
+        }, []);
+        if (!focusId || !isMobileAgent()) return null;
         return (
                 <ShadowWrapper
                         tagName={"virtual-keypad" as "div"}
@@ -216,12 +224,14 @@ export function VirtualKeypad({
                 >
                         <div
                                 onFocus={handleFocus}
-				onBlur={onBlur}
-				tabIndex={-1}
-				className="keypad-container"
-				style={{
-					left: viewport.offsetLeft,
-					width: viewport.width,
+                                onBlur={onBlur}
+                                tabIndex={-1}
+                                className="keypad-container"
+                                onContextMenu={preventContextMenu}
+                                onSelect={preventSelection}
+                                style={{
+                                        left: viewport.offsetLeft,
+                                        width: viewport.width,
 					top: Math.round(
 						viewport.offsetTop + viewport.height - 200 / viewport.scale,
 					),


### PR DESCRIPTION
## Summary
- remove global listeners that blocked selection and context menus across all pages
- scope right-click and selection prevention to the virtual keypad overlay element only

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928e78ef3408331be7bdb3d781a12f1)